### PR TITLE
Make chatbot API URL configurable via REACT_APP_API_URL

### DIFF
--- a/src/components/ChatBot.js
+++ b/src/components/ChatBot.js
@@ -42,7 +42,8 @@ export default function ChatBot() {
       console.log('Sending query to backend:', userMessage);
       console.log('With conversation history:', conversationHistory.length, 'messages');
 
-      const response = await fetch('http://localhost:8000/chat', {
+      const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+      const response = await fetch(`${apiUrl}/chat`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- ChatBot.js had `http://localhost:8000/chat` hardcoded, which means the prod build always points at the user's own machine and the chatbot is broken on courses.sbcs.io
- Reads `process.env.REACT_APP_API_URL` instead, falling back to `http://localhost:8000` for local dev

## After this merges
- Set `REACT_APP_API_URL` in Vercel (Production + Preview) to wherever the FastAPI backend is hosted, then redeploy
- The FastAPI backend in `chatbot/` still needs to be deployed somewhere with `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `GROQ_API_KEY` set on that host

## Test plan
- [ ] Local dev: chatbot still hits `localhost:8000` when `REACT_APP_API_URL` is unset
- [ ] Set `REACT_APP_API_URL` in Vercel, redeploy, confirm chatbot calls the production backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)