### PR TITLE
Integrate SBCS GE tracker + Josh's taken-courses tracker

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import LoginPage from './pages/LoginPAGE';
 import Home from './pages/Home';
 import CatPage from './pages/CatPage';
 import ChatBotPage from './pages/ChatBotPage';
+import DegreeProgressPage from './pages/DegreeProgressPage';
 import { useAuth } from './hooks/useAuth';
 
 
@@ -37,6 +38,7 @@ function App() {
               <Navbar />
               <Routes>
                 <Route path="/" element={<Home />} />
+                <Route path="/degree-progress" element={<DegreeProgressPage />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/cat" element={<CatPage />} />
               </Routes>

--- a/src/components/CompletedCoursesPanel.js
+++ b/src/components/CompletedCoursesPanel.js
@@ -1,0 +1,59 @@
+import React, { useMemo } from 'react';
+
+export default function CompletedCoursesPanel({
+  courseMap,
+  courseCodeMap = {},
+  completedCourses,
+  onRemoveCourse,
+}) {
+  const completedCourseList = useMemo(() => (
+    Array.from(completedCourses)
+      .map((key) => {
+        const course = courseMap[key] || courseCodeMap[key] || null;
+        return course ? { key, course } : null;
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.course.code.localeCompare(b.course.code))
+  ), [completedCourses, courseMap, courseCodeMap]);
+
+  return (
+    <div className="mb-2 p-3 bg-green-50 border border-green-200 rounded-lg">
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <h3 className="text-sm font-semibold text-green-900">Taken Courses</h3>
+        <span className="text-xs font-medium text-green-800 bg-green-100 px-2 py-1 rounded-full">
+          {completedCourseList.length} tracked
+        </span>
+      </div>
+
+      {completedCourseList.length === 0 ? (
+        <p className="text-xs text-green-900">
+          No completed classes tracked yet. Switch to Completed Mode and click a course node to add it.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {completedCourseList.map(({ key, course }) => (
+              <span
+                key={key}
+                className="group inline-flex items-center gap-1 bg-green-200 text-green-900 px-2 py-1 rounded text-sm"
+              >
+                {course.code}
+                <button
+                  onClick={() => onRemoveCourse(key)}
+                  className="ml-1 rounded-full px-1 text-red-700 opacity-0 transition group-hover:opacity-100 focus:opacity-100 hover:text-red-900"
+                  aria-label={`Remove ${course.code} from taken courses`}
+                  title={`Remove ${course.code}`}
+                >
+                  x
+                </button>
+              </span>
+            ))}
+          </div>
+          <p className="text-xs text-green-900">
+            Hover over a tracked course to remove it directly from this list.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/DegreeProgress.js
+++ b/src/components/DegreeProgress.js
@@ -1,0 +1,244 @@
+import { useState, useEffect, useMemo } from "react";
+import wrtData from "../data/SBCS/WRT.json";
+import artsData from "../data/SBCS/ARTS.json";
+import gloData from "../data/SBCS/GLO.json";
+import humData from "../data/SBCS/HUM.json";
+import langData from "../data/SBCS/LANG.json";
+import qpsData from "../data/SBCS/QPS.json";
+import sbsData from "../data/SBCS/SBS.json";
+import snwData from "../data/SBCS/SNW.json";
+import techData from "../data/SBCS/TECH.json";
+import usaData from "../data/SBCS/USA.json";
+import { useUserProgress } from "../hooks/useUserProgress";
+
+const REQUIRED_CATEGORIES = ["ARTS", "GLO", "HUM", "LANG", "QPS", "SBS", "SNW", "TECH", "USA", "WRT"];
+
+const EXEMPTION_MAJORS = [
+  "CEAS",
+  "Athletic Training",
+  "Respiratory Care",
+  "Clinical Laboratory Sciences",
+  "Social Work",
+];
+
+const MAJOR_OPTIONS = [
+  "CSE - Computer Science and Engineering",
+  "AMS - Applied Mathematics and Statistics",
+  ...EXEMPTION_MAJORS,
+  "Other",
+];
+
+const normalizeCode = (s) => (s || "").trim().toUpperCase();
+
+const toCourse = (c) => ({
+  code: c.code || `${c.deptCode} ${c.number}`,
+  name: c.title || c.name || "",
+  credits: c.credits || 0,
+});
+
+export default function DegreeProgress() {
+  const { progress, save, isAuthenticated, saving } = useUserProgress();
+
+  // External courses (typed by user) are the source of truth for what fulfills GE.
+  // Persisted on the same `external_courses` field the graph already uses.
+  const externalCourses = useMemo(
+    () => new Set((progress?.external_courses || []).map(normalizeCode)),
+    [progress]
+  );
+
+  const sbcsMap = useMemo(
+    () => ({
+      ARTS: artsData.map(toCourse),
+      GLO: gloData.map(toCourse),
+      HUM: humData.map(toCourse),
+      LANG: langData.map(toCourse),
+      QPS: qpsData.map(toCourse),
+      SBS: sbsData.map(toCourse),
+      SNW: snwData.map(toCourse),
+      TECH: techData.map(toCourse),
+      USA: usaData.map(toCourse),
+      WRT: wrtData.map(toCourse),
+    }),
+    []
+  );
+
+  const [selectedMajorForCheck, setSelectedMajorForCheck] = useState(MAJOR_OPTIONS[0]);
+  const [courseInput, setCourseInput] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState(REQUIRED_CATEGORIES[0]);
+
+  const isLangExempt =
+    selectedMajorForCheck !== "Other" &&
+    EXEMPTION_MAJORS.some((m) => m.toLowerCase() === selectedMajorForCheck.toLowerCase());
+
+  const requirements = useMemo(() => {
+    return REQUIRED_CATEGORIES.map((category) => {
+      if (category === "LANG" && isLangExempt) {
+        return { category, completed: true, status: "Exempt", courses: sbcsMap[category] };
+      }
+      const validCodes = new Set(sbcsMap[category].map((c) => normalizeCode(c.code)));
+      const matched = Array.from(externalCourses).some((code) => validCodes.has(code));
+      return {
+        category,
+        completed: matched,
+        status: matched ? "Fulfilled" : "In Progress",
+        courses: sbcsMap[category],
+      };
+    });
+  }, [externalCourses, isLangExempt, sbcsMap]);
+
+  useEffect(() => {
+    if (!REQUIRED_CATEGORIES.includes(selectedCategory)) {
+      setSelectedCategory(REQUIRED_CATEGORIES[0]);
+    }
+  }, [selectedCategory]);
+
+  const persist = async (nextExternalSet) => {
+    if (!isAuthenticated) return;
+    try {
+      await save({
+        completedCourses: progress?.completed_courses || [],
+        externalCourses: Array.from(nextExternalSet),
+        standing: progress?.standing || 1,
+        majorId: progress?.major_id || null,
+      });
+    } catch (err) {
+      console.error("Failed to save GE progress:", err);
+    }
+  };
+
+  const addUserCourse = async (raw) => {
+    const code = normalizeCode(raw);
+    if (!code) return;
+    if (externalCourses.has(code)) {
+      setCourseInput("");
+      return;
+    }
+    const next = new Set(externalCourses);
+    next.add(code);
+    setCourseInput("");
+    await persist(next);
+  };
+
+  const removeUserCourse = async (code) => {
+    const next = new Set(externalCourses);
+    next.delete(code);
+    await persist(next);
+  };
+
+  const selectedReq = requirements.find((r) => r.category === selectedCategory);
+
+  return (
+    <div className="bg-[#F9FAFB] text-gray-900">
+      <div className="max-w-6xl mx-auto mt-10 flex flex-col md:flex-row gap-6 px-4">
+        <div className="flex-1">
+          <h1 className="text-2xl font-semibold mb-6">General Education Requirements</h1>
+
+          <div className="mb-6 p-4 bg-white rounded-md border border-gray-200">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">Major</label>
+                <select
+                  value={selectedMajorForCheck}
+                  onChange={(e) => setSelectedMajorForCheck(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                >
+                  {MAJOR_OPTIONS.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700">
+                  Add completed GE course
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    value={courseInput}
+                    onChange={(e) => setCourseInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        addUserCourse(courseInput);
+                      }
+                    }}
+                    placeholder="e.g., AAS 209"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  />
+                  <button
+                    onClick={() => addUserCourse(courseInput)}
+                    disabled={saving}
+                    className="px-3 py-2 bg-blue-600 text-white rounded-md disabled:opacity-50"
+                  >
+                    Add
+                  </button>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {Array.from(externalCourses).map((c) => (
+                    <span key={c} className="bg-gray-100 px-2 py-1 rounded flex items-center gap-2">
+                      <span className="text-sm">{c}</span>
+                      <button onClick={() => removeUserCourse(c)} className="text-red-600">×</button>
+                    </span>
+                  ))}
+                </div>
+                {!isAuthenticated && (
+                  <p className="mt-2 text-xs text-amber-600">
+                    Sign in to save your progress.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            {requirements.map((req) => (
+              <div
+                key={req.category}
+                onClick={() => setSelectedCategory(req.category)}
+                className={`p-4 rounded-xl border transition cursor-pointer flex items-center justify-between shadow-sm hover:shadow-md ${
+                  req.completed ? "border-blue-200 bg-blue-50" : "border-gray-200 bg-white"
+                } ${selectedCategory === req.category ? "ring-2 ring-blue-300" : ""}`}
+              >
+                <div className="flex items-center gap-3">
+                  <input
+                    type="checkbox"
+                    checked={req.completed}
+                    disabled
+                    aria-disabled
+                    title={req.completed ? "Requirement fulfilled" : "Requirement not fulfilled"}
+                    className="w-5 h-5 accent-blue-500 cursor-not-allowed"
+                    readOnly
+                  />
+                  <p className="font-semibold">{req.category}</p>
+                </div>
+                <span
+                  className={`px-4 py-1 rounded-full border text-sm ${
+                    req.completed ? "text-gray-600" : "text-gray-500"
+                  }`}
+                >
+                  {req.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {selectedReq && (
+          <div className="w-full md:w-[450px] bg-white shadow-md rounded-xl p-5">
+            <h2 className="text-xl font-semibold mb-2">{selectedReq.category}</h2>
+            <p className="text-sm text-gray-500 mb-4">Courses that fulfill this requirement</p>
+            <div className="flex flex-col gap-4 max-h-[150vh] overflow-y-auto pr-2">
+              {selectedReq.courses.map((course, idx) => (
+                <div key={idx} className="border rounded-xl p-3 hover:bg-gray-50 transition">
+                  <p className="font-bold text-sm">
+                    <span className="font-normal">{course.name || course.code}</span>
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GraphComponent.js
+++ b/src/components/GraphComponent.js
@@ -768,6 +768,8 @@ export default function CourseGraph({ onNodeClick }) {
           deptCode={selectedMajor}
           selectedSlugs={selectedSpecSlugs}
           onChange={setSelectedSpecSlugs}
+          completedCourses={completedCourses}
+          externalCourses={externalCourses}
         />
 
         {loading ? (

--- a/src/components/GraphComponent.js
+++ b/src/components/GraphComponent.js
@@ -22,6 +22,7 @@ import CourseGraphProcessor from './CourseGraphProcessor';
 import SpecializationSelector, {
   highlightedCoursesFor,
 } from './SpecializationSelector';
+import CompletedCoursesPanel from './CompletedCoursesPanel';
 import {
   buildCourseMap,
   buildCourseCodeMap,
@@ -191,6 +192,19 @@ export default function CourseGraph({ onNodeClick }) {
     () => highlightedCoursesFor(selectedMajor, selectedSpecSlugs),
     [selectedMajor, selectedSpecSlugs]
   );
+
+  const completedCourseCodes = useMemo(() => {
+    const codes = Array.from(completedCourses).map((value) => {
+      const byId = courseMap[value];
+      if (byId?.code) return byId.code;
+
+      const byCode = courseCodeMap[value];
+      if (byCode?.code) return byCode.code;
+
+      return value;
+    });
+    return new Set(codes);
+  }, [completedCourses, courseMap, courseCodeMap]);
 
   useEffect(() => {
     if (progress) {
@@ -498,28 +512,47 @@ export default function CourseGraph({ onNodeClick }) {
 
   const updateGraphVisuals = (gSel, colorFn, clickHandler) => {
     if (!gSel) return;
+    const hasSpecHighlight = highlightedCodes.size > 0;
 
     // Nodes
+    gSel
+      .selectAll('g.node')
+      .attr('opacity', (d) =>
+        !hasSpecHighlight || highlightedCodes.has(d.code) ? 1 : 0.42
+      )
+      .on('click', (_, d) => clickHandler(d.id));
+
     gSel
       .selectAll('g.node > circle')
       .attr('fill', (d) => colorFn(d.id))
       .attr('stroke', (d) =>
-        highlightedCodes.has(d.code) ? '#f59e0b' : '#333'
+        highlightedCodes.has(d.code) ? '#3b82f6' : '#333'
       )
       .attr('stroke-width', (d) =>
-        highlightedCodes.has(d.code) ? 4 : 1.5
+        highlightedCodes.has(d.code) ? 4.5 : 1.5
+      )
+      .attr('filter', (d) =>
+        highlightedCodes.has(d.code) ? 'drop-shadow(0 0 8px rgba(59, 130, 246, 0.35))' : null
       );
-
-    gSel.selectAll('g.node').on('click', (_, d) => clickHandler(d.id));
 
     // Links — DO NOT force arrows here
     gSel
       .selectAll('.links line')
       .attr('stroke-opacity', (d) => {
-        if (!selectedCourse) return 0.12; // nothing selected → all faded
-
         const sourceId = typeof d.source === 'object' ? d.source.id : d.source;
         const targetId = typeof d.target === 'object' ? d.target.id : d.target;
+        const sourceCode = courseMap[sourceId]?.code;
+        const targetCode = courseMap[targetId]?.code;
+
+        if (hasSpecHighlight && !selectedCourse) {
+          return sourceCode && targetCode &&
+            highlightedCodes.has(sourceCode) &&
+            highlightedCodes.has(targetCode)
+            ? 0.55
+            : 0.06;
+        }
+
+        if (!selectedCourse) return 0.12; // nothing selected → all faded
 
         if (mode === 'prereqs') {
           const prereqIds = getAllPrerequisites(selectedCourse, courseMap);
@@ -533,10 +566,20 @@ export default function CourseGraph({ onNodeClick }) {
         return 0.12;
       })
       .attr('stroke-width', (d) => {
-        if (!selectedCourse) return 1;
-
         const sourceId = typeof d.source === 'object' ? d.source.id : d.source;
         const targetId = typeof d.target === 'object' ? d.target.id : d.target;
+        const sourceCode = courseMap[sourceId]?.code;
+        const targetCode = courseMap[targetId]?.code;
+
+        if (hasSpecHighlight && !selectedCourse) {
+          return sourceCode && targetCode &&
+            highlightedCodes.has(sourceCode) &&
+            highlightedCodes.has(targetCode)
+            ? 2
+            : 1;
+        }
+
+        if (!selectedCourse) return 1;
 
         if (mode === 'prereqs') {
           const prereqIds = getAllPrerequisites(selectedCourse, courseMap);
@@ -550,10 +593,20 @@ export default function CourseGraph({ onNodeClick }) {
         return 1;
       })
       .attr('marker-end', (d) => {
-        if (!selectedCourse) return null;
-
         const sourceId = typeof d.source === 'object' ? d.source.id : d.source;
         const targetId = typeof d.target === 'object' ? d.target.id : d.target;
+        const sourceCode = courseMap[sourceId]?.code;
+        const targetCode = courseMap[targetId]?.code;
+
+        if (hasSpecHighlight && !selectedCourse) {
+          return sourceCode && targetCode &&
+            highlightedCodes.has(sourceCode) &&
+            highlightedCodes.has(targetCode)
+            ? 'url(#arrow-blue)'
+            : null;
+        }
+
+        if (!selectedCourse) return null;
 
         if (mode === 'prereqs') {
           const prereqIds = getAllPrerequisites(selectedCourse, courseMap);
@@ -719,6 +772,14 @@ export default function CourseGraph({ onNodeClick }) {
           </div>
         )}
 
+        <CompletedCoursesPanel
+          courseMap={courseMap}
+          courseCodeMap={courseCodeMap}
+          completedCourses={completedCourses}
+          mode={mode}
+          onRemoveCourse={toggleCompleted}
+        />
+
         {mode === 'completed' && (
           <div className="mb-2 p-3 bg-gray-100 rounded-lg">
             <h3 className="text-sm font-semibold mb-2">External Courses (AMS, MAT, etc.)</h3>
@@ -768,6 +829,7 @@ export default function CourseGraph({ onNodeClick }) {
           deptCode={selectedMajor}
           selectedSlugs={selectedSpecSlugs}
           onChange={setSelectedSpecSlugs}
+          completedCourseCodes={completedCourseCodes}
         />
 
         {loading ? (

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -1,26 +1,7 @@
 // Legend.js
-import React, { useEffect, useState } from 'react';
-import NodeInfo from './NodeInfo';
+import React from 'react';
 
 export default function Legend() {
-  const [selectedCourse, setSelectedCourse] = useState(null);
-
-  useEffect(() => {
-    const handler = (e) => setSelectedCourse(e?.detail?.course ?? null);
-    window.addEventListener('course:selected', handler);
-    return () => window.removeEventListener('course:selected', handler);
-  }, []);
-
-  // ✅ lower + slightly left (more centered in the whitespace)
-  const wrapperStyle = {
-    width: '450px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
-    marginTop: '305px',
-    marginLeft: '-30px',  
-  };
-
   const boxStyle = {
     backgroundColor: '#ffffffff',
     color: 'black',
@@ -28,8 +9,7 @@ export default function Legend() {
     borderRadius: '20px',
     boxShadow: '0 10px 20px rgba(224, 221, 221, 0.3)',
     fontFamily: 'sans-serif',
-    width: '450px',
-    height: '220px',
+    width: '100%',
     border: '2px solid #000000ff',
   };
 
@@ -58,7 +38,7 @@ export default function Legend() {
   const textStyle = { fontSize: '14px', marginBottom: '8px' };
 
   return (
-    <div style={wrapperStyle}>
+    <div style={{ marginTop: '278px' }}>
       <div style={boxStyle}>
         <h1 style={{ fontSize: '18px', marginBottom: '8px' }}>Legend</h1>
         <h2 style={{ fontSize: '16px', marginBottom: '8px' }}>Node Colors</h2>
@@ -72,11 +52,9 @@ export default function Legend() {
           <span style={circleStyle('#60A5FA')}></span> Unlocked Course (you can take the course now)
         </h3>
         <h3 style={textStyle}>
-          <span style={ringStyle('#f59e0b')}></span> In Selected Specialization
+          <span style={ringStyle('#3b82f6')}></span> In Selected Specialization
         </h3>
       </div>
-
-      <NodeInfo course={selectedCourse} />
     </div>
   );
 }

--- a/src/components/RadialGraphComponent.js
+++ b/src/components/RadialGraphComponent.js
@@ -8,6 +8,7 @@ import React, {
 import * as d3 from 'd3';
 import courses from '../data/sbu_cse_courses_new_schema.json';
 import CourseGraphProcessor from './CourseGraphProcessor';
+import CompletedCoursesPanel from './CompletedCoursesPanel';
 import {
   buildCourseMap,
   buildCourseCodeMap,
@@ -477,6 +478,14 @@ export default function RadialGraphComponent({ onNodeClick }) {
           <div className="text-sm text-gray-600 mb-4">
             Green = Completed | Blue = Available | Gray = Locked. Click to view details without modifying state.
           </div>}
+
+        <CompletedCoursesPanel
+          courseMap={courseMap}
+          courseCodeMap={courseCodeMap}
+          completedCourses={completedCourses}
+          mode={mode}
+          onRemoveCourse={toggleCompleted}
+        />
 
         {/* ---------- External Courses Management ---------- */}
         {mode === 'completed' && (

--- a/src/components/SpecializationDetailsPanel.js
+++ b/src/components/SpecializationDetailsPanel.js
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+
+export default function SpecializationDetailsPanel() {
+  const [specialization, setSpecialization] = useState(null);
+
+  useEffect(() => {
+    const handler = (event) => setSpecialization(event?.detail?.specialization ?? null);
+    window.addEventListener('specialization:selected', handler);
+    return () => window.removeEventListener('specialization:selected', handler);
+  }, []);
+
+  if (!specialization) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-emerald-200 bg-white p-3 shadow-sm">
+      <div className="mb-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-emerald-700">
+          Specialization Details
+        </div>
+        <h3 className="text-sm font-semibold text-slate-900">{specialization.name}</h3>
+        <p className="text-xs text-slate-600">
+          Track listed requirements for this path and see what courses are still left.
+        </p>
+      </div>
+
+      <div className="grid gap-2 mb-3">
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-2.5">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Overview</div>
+          <div className="mt-1 text-xs text-slate-700">{specialization.majorName}</div>
+          <div className="mt-1 flex flex-wrap gap-2">
+            <span className="rounded-full bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-700">
+              {specialization.totalCount} listed
+            </span>
+            <span className="rounded-full bg-green-100 px-2 py-1 text-[11px] font-medium text-green-800">
+              {specialization.completedCount} tracked
+            </span>
+            <span className="rounded-full bg-amber-100 px-2 py-1 text-[11px] font-medium text-amber-800">
+              {specialization.remainingCount} left
+            </span>
+          </div>
+          <a
+            href={specialization.majorUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-block text-xs font-medium text-emerald-700 hover:text-emerald-900 hover:underline"
+          >
+            View catalog requirements
+          </a>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {specialization.sections.map((section, index) => {
+          const title = section.label || `Requirement Group ${index + 1}`;
+          const trackedList = section.trackedCourses || [];
+          const remainingList = section.remainingCourses || [];
+
+          return (
+            <div key={`${specialization.slug}-${title}-${index}`} className="rounded-lg border border-slate-200 p-2.5">
+              <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <div className="text-xs font-semibold text-slate-900">{title}</div>
+                  <div className="text-[11px] text-slate-500">
+                    {section.targetCount == null
+                      ? `${section.completedCount}/${section.courses.length} listed courses tracked`
+                      : `${section.completedCount}/${section.targetCount} target tracked`}
+                  </div>
+                </div>
+                <span className="rounded-full bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-700">
+                  {section.targetCount == null ? `${remainingList.length} untracked` : `${section.remainingCount} left`}
+                </span>
+              </div>
+
+              {trackedList.length > 0 && (
+                <div className="mb-2">
+                  <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-green-800">Tracked</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {trackedList.map((courseCode) => (
+                      <span
+                        key={`${specialization.slug}-${title}-tracked-${courseCode}`}
+                        className="rounded-full border border-green-900 bg-green-800 px-2.5 py-1 text-[11px] font-medium text-green-50"
+                      >
+                        {courseCode}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {remainingList.length > 0 && (
+                <div>
+                  <div className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Still Left</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {remainingList.map((courseCode) => (
+                      <span
+                        key={`${specialization.slug}-${title}-remaining-${courseCode}`}
+                        className="rounded-full border border-slate-300 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700"
+                      >
+                        {courseCode}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SpecializationSelector.js
+++ b/src/components/SpecializationSelector.js
@@ -1,27 +1,150 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import specializationsData from '../data/courses/specializations.json';
 
-// Map dept code -> catalog poid for the BS/BE program. Add entries as more
-// majors gain specializations in the catalog.
 const DEPT_TO_POID = {
-  CSE: 318, // Computer Science, BS
-  ISE: 384, // Information Systems, BS
-  PHY: 438, // Physics, BS
-  EST: 414, // Technological Systems Management, BS
+  CSE: 318,
+  ISE: 384,
+  PHY: 438,
+  EST: 414,
+};
+
+const NUMBER_WORDS = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
 };
 
 function findMajorEntry(deptCode) {
   const poid = DEPT_TO_POID[deptCode];
   if (!poid) return null;
-  return specializationsData.find((m) => m.poid === poid) || null;
+  return specializationsData.find((major) => major.poid === poid) || null;
+}
+
+function inferSectionTarget(label, courses) {
+  if (!courses?.length) return 0;
+  if (!label) return null;
+
+  const normalized = label.toLowerCase();
+  const requiredMatch = normalized.match(/\b(one|two|three|four|five|six|seven|eight|\d+)\b/);
+
+  if (normalized.includes('required') || normalized.includes('core') || normalized.includes('project')) {
+    if (requiredMatch) {
+      const token = requiredMatch[1];
+      return Number.isNaN(Number(token)) ? NUMBER_WORDS[token] : Number(token);
+    }
+    return courses.length;
+  }
+
+  if (normalized.includes('elective') || normalized.includes('following') || normalized.includes('additional')) {
+    if (requiredMatch) {
+      const token = requiredMatch[1];
+      return Number.isNaN(Number(token)) ? NUMBER_WORDS[token] : Number(token);
+    }
+    return null;
+  }
+
+  return courses.length;
+}
+
+function buildSectionProgress(section, completedCourseCodes) {
+  const courses = section.courses || [];
+  const targetCount = inferSectionTarget(section.label, courses);
+  const completedCount = courses.filter((code) => completedCourseCodes.has(code)).length;
+  const remainingCount = targetCount == null
+    ? courses.length - completedCount
+    : Math.max(targetCount - completedCount, 0);
+  const trackedCourses = courses.filter((code) => completedCourseCodes.has(code));
+  const remainingCourses = courses.filter((code) => !completedCourseCodes.has(code));
+
+  return {
+    ...section,
+    targetCount,
+    completedCount,
+    remainingCount,
+    trackedCourses,
+    remainingCourses,
+  };
+}
+
+function specProgress(spec, completedCourseCodes) {
+  const completedCount = (spec.courses || []).filter((code) => completedCourseCodes.has(code)).length;
+  return {
+    totalCount: spec.courses?.length || 0,
+    completedCount,
+    remainingCount: Math.max((spec.courses?.length || 0) - completedCount, 0),
+  };
 }
 
 export default function SpecializationSelector({
   deptCode,
   selectedSlugs,
   onChange,
+  completedCourseCodes = new Set(),
 }) {
   const major = findMajorEntry(deptCode);
+  const [detailSlug, setDetailSlug] = useState(null);
+
+  useEffect(() => {
+    if (!major || major.specializations.length === 0) {
+      setDetailSlug(null);
+      return;
+    }
+
+    const availableSlugs = major.specializations.map((spec) => spec.slug);
+    setDetailSlug((current) => {
+      if (current && availableSlugs.includes(current)) return current;
+      return null;
+    });
+  }, [major]);
+
+  const detailSpec = useMemo(() => {
+    if (!major || !detailSlug) return null;
+    return major.specializations.find((spec) => spec.slug === detailSlug) || null;
+  }, [major, detailSlug]);
+
+  useEffect(() => {
+    if (!major || !detailSpec) {
+      window.dispatchEvent(
+        new CustomEvent('specialization:selected', { detail: { specialization: null } })
+      );
+      return;
+    }
+
+    const detailSections = (detailSpec.sections?.length ? detailSpec.sections : [
+      { label: 'Listed Courses', courses: detailSpec.courses || [] },
+    ]).map((section) => buildSectionProgress(section, completedCourseCodes));
+
+    const completedCount = (detailSpec.courses || []).filter((code) => completedCourseCodes.has(code)).length;
+
+    window.dispatchEvent(
+      new CustomEvent('specialization:selected', {
+        detail: {
+          specialization: {
+            majorName: major.majorName,
+            majorUrl: major.url,
+            name: detailSpec.name,
+            slug: detailSpec.slug,
+            totalCount: detailSpec.courses?.length || 0,
+            completedCount,
+            remainingCount: Math.max((detailSpec.courses?.length || 0) - completedCount, 0),
+            sections: detailSections,
+          },
+        },
+      })
+    );
+  }, [major, detailSpec, completedCourseCodes]);
+
+  useEffect(() => () => {
+    window.dispatchEvent(
+      new CustomEvent('specialization:selected', { detail: { specialization: null } })
+    );
+  }, []);
+
   if (!major || major.specializations.length === 0) return null;
 
   const toggle = (slug) => {
@@ -34,54 +157,104 @@ export default function SpecializationSelector({
   const clearAll = () => onChange(new Set());
 
   const anyChecked = selectedSlugs.size > 0;
+  const highlightedCount = major.specializations.filter((spec) => selectedSlugs.has(spec.slug)).length;
 
   return (
-    <div className="mb-2 p-3 bg-amber-50 rounded-lg border border-amber-200">
-      <div className="flex items-center justify-between mb-1">
-        <h3 className="text-sm font-semibold">
-          Specializations
-          <span className="text-xs text-gray-500 ml-2">
-            ({major.majorName})
+    <div className="mb-3 rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-teal-50 p-3 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900">Specializations</h3>
+          <p className="text-xs text-slate-600">
+            Highlight a track on the graph, or open its details in the right sidebar.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-semibold text-emerald-800">
+            {major.specializations.length} options
           </span>
-        </h3>
-        {anyChecked && (
-          <button
-            onClick={clearAll}
-            className="text-xs text-amber-700 hover:text-amber-900 underline"
-          >
-            Clear
-          </button>
-        )}
+          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
+            {highlightedCount} highlighted
+          </span>
+          {anyChecked && (
+            <button
+              onClick={clearAll}
+              className="rounded-full border border-emerald-300 px-2.5 py-1 text-[11px] font-medium text-emerald-800 transition hover:bg-emerald-100"
+            >
+              Clear highlights
+            </button>
+          )}
+        </div>
       </div>
-      <p className="text-xs text-gray-600 mb-2">
-        Check a specialization to highlight its required courses on the graph.
-      </p>
-      <div className="space-y-1">
-        {major.specializations.map((spec) => (
-          <label
-            key={spec.slug}
-            className="flex items-start gap-2 text-sm cursor-pointer hover:bg-amber-100 rounded p-1"
-          >
-            <input
-              type="checkbox"
-              checked={selectedSlugs.has(spec.slug)}
-              onChange={() => toggle(spec.slug)}
-              className="mt-1"
-            />
-            <span className="flex-1">
-              <span className="font-medium">{spec.name}</span>
-              <span className="text-xs text-gray-500 ml-1">
-                ({spec.courses.length} courses)
-              </span>
-            </span>
-          </label>
-        ))}
+
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {major.specializations.map((spec) => {
+          const isSelected = selectedSlugs.has(spec.slug);
+          const isOpen = detailSlug === spec.slug;
+          const progress = specProgress(spec, completedCourseCodes);
+
+          return (
+            <div
+              key={spec.slug}
+              className={`rounded-xl border p-3 transition ${
+                isOpen
+                  ? 'border-emerald-500 bg-white shadow-md'
+                  : 'border-emerald-100 bg-white/80 hover:border-emerald-300 hover:bg-white'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1">
+                  <div className="text-sm font-semibold text-slate-900">{spec.name}</div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {spec.sections?.length || 0} requirement groups
+                  </div>
+                </div>
+
+                <label className="flex items-center gap-2 rounded-full bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-800">
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggle(spec.slug)}
+                    className="h-4 w-4 accent-emerald-600"
+                  />
+                  Highlight
+                </label>
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2">
+                <span className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-700">
+                  {progress.completedCount}/{progress.totalCount} tracked
+                </span>
+                <span className="rounded-full bg-emerald-100 px-2 py-1 text-xs text-emerald-800">
+                  {progress.remainingCount} left
+                </span>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setDetailSlug(isOpen ? null : spec.slug)}
+                  className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition ${
+                    isOpen
+                      ? 'border-emerald-600 bg-emerald-600 text-white'
+                      : 'border-slate-300 bg-white text-slate-700 hover:border-emerald-300 hover:text-emerald-800'
+                  }`}
+                >
+                  {isOpen ? 'Hide details' : 'Show details'}
+                </button>
+              </div>
+            </div>
+          );
+        })}
       </div>
+
+      {detailSlug && (
+        <p className="mt-3 text-xs text-slate-500">
+          Specialization details are shown in the right sidebar under the legend.
+        </p>
+      )}
     </div>
   );
 }
 
-// Helper consumed by GraphComponent to compute the highlight set.
 export function highlightedCoursesFor(deptCode, selectedSlugs) {
   const major = findMajorEntry(deptCode);
   if (!major) return new Set();

--- a/src/components/SpecializationSelector.js
+++ b/src/components/SpecializationSelector.js
@@ -16,10 +16,25 @@ function findMajorEntry(deptCode) {
   return specializationsData.find((m) => m.poid === poid) || null;
 }
 
+function countDone(courses, completed, external) {
+  let n = 0;
+  for (const c of courses) {
+    if (completed.has(c) || external.has(c)) n += 1;
+  }
+  return n;
+}
+
+function shortLabel(s, max = 22) {
+  if (!s) return 'Other';
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
 export default function SpecializationSelector({
   deptCode,
   selectedSlugs,
   onChange,
+  completedCourses = new Set(),
+  externalCourses = new Set(),
 }) {
   const major = findMajorEntry(deptCode);
   if (!major || major.specializations.length === 0) return null;
@@ -32,50 +47,150 @@ export default function SpecializationSelector({
   };
 
   const clearAll = () => onChange(new Set());
-
   const anyChecked = selectedSlugs.size > 0;
 
+  // Per-spec progress
+  const specs = major.specializations.map((spec) => {
+    const total = spec.courses.length;
+    const done = countDone(spec.courses, completedCourses, externalCourses);
+    return { ...spec, total, done, pct: total ? done / total : 0 };
+  });
+
+  // Aggregate over selected specs
+  const sel = specs.filter((s) => selectedSlugs.has(s.slug));
+  const selDone = sel.reduce((a, s) => a + s.done, 0);
+  const selTotal = sel.reduce((a, s) => a + s.total, 0);
+  const selPct = selTotal ? selDone / selTotal : 0;
+
   return (
-    <div className="mb-2 p-3 bg-amber-50 rounded-lg border border-amber-200">
-      <div className="flex items-center justify-between mb-1">
-        <h3 className="text-sm font-semibold">
-          Specializations
-          <span className="text-xs text-gray-500 ml-2">
-            ({major.majorName})
-          </span>
-        </h3>
+    <div className="mb-3 bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-gray-100 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-semibold text-gray-900 leading-tight">
+            Specializations
+          </h3>
+          <p className="text-xs text-gray-500 mt-0.5 truncate">
+            {major.majorName} · {specs.length} available
+          </p>
+        </div>
         {anyChecked && (
           <button
             onClick={clearAll}
-            className="text-xs text-amber-700 hover:text-amber-900 underline"
+            className="text-xs font-medium text-amber-700 hover:text-amber-900 shrink-0 mt-1"
           >
-            Clear
+            Clear all
           </button>
         )}
       </div>
-      <p className="text-xs text-gray-600 mb-2">
-        Check a specialization to highlight its required courses on the graph.
-      </p>
-      <div className="space-y-1">
-        {major.specializations.map((spec) => (
-          <label
-            key={spec.slug}
-            className="flex items-start gap-2 text-sm cursor-pointer hover:bg-amber-100 rounded p-1"
-          >
-            <input
-              type="checkbox"
-              checked={selectedSlugs.has(spec.slug)}
-              onChange={() => toggle(spec.slug)}
-              className="mt-1"
-            />
-            <span className="flex-1">
-              <span className="font-medium">{spec.name}</span>
-              <span className="text-xs text-gray-500 ml-1">
-                ({spec.courses.length} courses)
-              </span>
+
+      {/* Aggregate progress when something is selected */}
+      {anyChecked && selTotal > 0 && (
+        <div className="px-4 py-2.5 bg-amber-50 border-b border-amber-100">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-xs font-semibold text-amber-900">
+              {sel.length} selected
             </span>
-          </label>
-        ))}
+            <span className="text-xs font-medium text-amber-900 tabular-nums">
+              {selDone} / {selTotal} courses completed
+            </span>
+          </div>
+          <div className="h-1.5 bg-amber-200 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-amber-600 transition-all duration-300"
+              style={{ width: `${selPct * 100}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Spec cards */}
+      <ul className="divide-y divide-gray-100">
+        {specs.map((spec) => {
+          const isChecked = selectedSlugs.has(spec.slug);
+          const isComplete = spec.total > 0 && spec.done === spec.total;
+
+          return (
+            <li key={spec.slug}>
+              <label
+                className={`flex items-start gap-3 px-4 py-3 cursor-pointer transition-colors border-l-4 ${
+                  isChecked
+                    ? 'bg-amber-50/60 border-amber-500'
+                    : 'border-transparent hover:bg-gray-50'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={() => toggle(spec.slug)}
+                  className="mt-1 h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
+                />
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-sm font-medium text-gray-900">
+                      {spec.name}
+                    </span>
+                    <span
+                      className={`text-xs font-semibold tabular-nums shrink-0 ${
+                        isComplete ? 'text-green-700' : 'text-gray-700'
+                      }`}
+                    >
+                      {spec.done} / {spec.total}
+                    </span>
+                  </div>
+
+                  {/* Progress bar */}
+                  <div className="mt-1.5 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full transition-all duration-300 ${
+                        isComplete ? 'bg-green-500' : 'bg-amber-400'
+                      }`}
+                      style={{ width: `${spec.pct * 100}%` }}
+                    />
+                  </div>
+
+                  {/* Sub-section badges */}
+                  {spec.sections.length > 1 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {spec.sections.map((sec, i) => {
+                        const secDone = countDone(
+                          sec.courses,
+                          completedCourses,
+                          externalCourses
+                        );
+                        const secComplete =
+                          sec.courses.length > 0 && secDone === sec.courses.length;
+                        return (
+                          <span
+                            key={i}
+                            title={sec.label || 'Other'}
+                            className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+                              secComplete
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-gray-100 text-gray-600'
+                            }`}
+                          >
+                            {shortLabel(sec.label)}: {secDone}/{sec.courses.length}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Footer hint */}
+      <div className="px-4 py-2 bg-gray-50 border-t border-gray-100">
+        <p className="text-[11px] text-gray-500">
+          Checked specializations get an amber ring on the graph. Mark courses
+          completed in <span className="font-medium">Completed Mode</span> to
+          fill the progress bars.
+        </p>
       </div>
     </div>
   );

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -34,6 +34,7 @@ const Navbar = () => {
         </div>
 
         <div className="space-x-4">
+          <a href="/chatbot" className="hover:text-gray-200">Chatbot</a>
           <a href="/about" className="hover:text-gray-200">About Us</a>
           <a href="/cat" className="hover:text-gray-200">CatPage</a>
         </div>

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -35,6 +35,7 @@ const Navbar = () => {
 
         <div className="space-x-4">
           <a href="/chatbot" className="hover:text-gray-200">Chatbot</a>
+          <a href="/degree-progress" className="hover:text-gray-200">Degree Progress</a>
           <a href="/about" className="hover:text-gray-200">About Us</a>
           <a href="/cat" className="hover:text-gray-200">CatPage</a>
         </div>

--- a/src/data/SBCS/ARTS.json
+++ b/src/data/SBCS/ARTS.json
@@ -1,0 +1,373 @@
+[
+    {
+        "id": "ccs-200",
+        "deptCode": "CCS",
+        "number": "200",
+        "code": "CCS 200",
+        "title": "CCS 200: Media History"
+    },
+    {
+        "id": "ccs-202",
+        "deptCode": "CCS",
+        "number": "202",
+        "code": "CCS 202",
+        "title": "CCS 202: Film Genres"
+    },
+    {
+        "id": "ccs-203",
+        "deptCode": "CCS",
+        "number": "203",
+        "code": "CCS 203",
+        "title": "CCS 203: Cinema History"
+    },
+    {
+        "id": "ccs-204",
+        "deptCode": "CCS",
+        "number": "204",
+        "code": "CCS 204",
+        "title": "CCS 204: The Stony Brook Film Festival: Films and Contexts"
+    },
+    {
+        "id": "cwl-202",
+        "deptCode": "CWL",
+        "number": "202",
+        "code": "CWL 202",
+        "title": "CWL 202: Introduction to Creative Writing: Writing Everything"
+    },
+    {
+        "id": "dan-101",
+        "deptCode": "DAN",
+        "number": "101",
+        "code": "DAN 101",
+        "title": "DAN 101: Movement & Somatic Learning"
+    },
+    {
+        "id": "dan-102",
+        "deptCode": "DAN",
+        "number": "102",
+        "code": "DAN 102",
+        "title": "DAN 102: Intro to World Dance Cultures"
+    },
+    {
+        "id": "dan-164",
+        "deptCode": "DAN",
+        "number": "164",
+        "code": "DAN 164",
+        "title": "DAN 164: Tap Technique and History"
+    },
+    {
+        "id": "dan-165",
+        "deptCode": "DAN",
+        "number": "165",
+        "code": "DAN 165",
+        "title": "DAN 165: Contemporary Dance I"
+    },
+    {
+        "id": "dan-166",
+        "deptCode": "DAN",
+        "number": "166",
+        "code": "DAN 166",
+        "title": "DAN 166: Ballet Technique I"
+    },
+    {
+        "id": "dan-167",
+        "deptCode": "DAN",
+        "number": "167",
+        "code": "DAN 167",
+        "title": "DAN 167: Jazz Dance Technique I"
+    },
+    {
+        "id": "dan-168",
+        "deptCode": "DAN",
+        "number": "168",
+        "code": "DAN 168",
+        "title": "DAN 168: World Dance I"
+    },
+    {
+        "id": "dan-264",
+        "deptCode": "DAN",
+        "number": "264",
+        "code": "DAN 264",
+        "title": "DAN 264: Movement Awareness and Analysis"
+    },
+    {
+        "id": "egl-140",
+        "deptCode": "EGL",
+        "number": "140",
+        "code": "EGL 140",
+        "title": "EGL 140: Shakespeare in Performance"
+    },
+    {
+        "id": "egl-220",
+        "deptCode": "EGL",
+        "number": "220",
+        "code": "EGL 220",
+        "title": "EGL 220: Critical Approaches to the Cinema"
+    },
+    {
+        "id": "egl-285",
+        "deptCode": "EGL",
+        "number": "285",
+        "code": "EGL 285",
+        "title": "EGL 285: Writing Workshop: Fiction"
+    },
+    {
+        "id": "egl-286",
+        "deptCode": "EGL",
+        "number": "286",
+        "code": "EGL 286",
+        "title": "EGL 286: Writing Workshop: Poetry"
+    },
+    {
+        "id": "egl-325",
+        "deptCode": "EGL",
+        "number": "325",
+        "code": "EGL 325",
+        "title": "EGL 325: Screenwriting"
+    },
+    {
+        "id": "egl-328",
+        "deptCode": "EGL",
+        "number": "328",
+        "code": "EGL 328",
+        "title": "EGL 328: Documentary Theatre Creation"
+    },
+    {
+        "id": "egl-386",
+        "deptCode": "EGL",
+        "number": "386",
+        "code": "EGL 386",
+        "title": "EGL 386: Advanced Poetry Workshop"
+    },
+    {
+        "id": "egl-387",
+        "deptCode": "EGL",
+        "number": "387",
+        "code": "EGL 387",
+        "title": "EGL 387: Playwriting"
+    },
+    {
+        "id": "eur-390",
+        "deptCode": "EUR",
+        "number": "390",
+        "code": "EUR 390",
+        "title": "EUR 390: Special Topics in European Studies"
+    },
+    {
+        "id": "flm-101",
+        "deptCode": "FLM",
+        "number": "101",
+        "code": "FLM 101",
+        "title": "FLM 101: Introduction to Filmmaking and Television: Visual Storytelling"
+    },
+    {
+        "id": "hon-201",
+        "deptCode": "HON",
+        "number": "201",
+        "code": "HON 201",
+        "title": "HON 201: The Arts and Society"
+    },
+    {
+        "id": "huf-211",
+        "deptCode": "HUF",
+        "number": "211",
+        "code": "HUF 211",
+        "title": "HUF 211: French Cinema"
+    },
+    {
+        "id": "hug-221",
+        "deptCode": "HUG",
+        "number": "221",
+        "code": "HUG 221",
+        "title": "HUG 221: German Cinema Since 1945"
+    },
+    {
+        "id": "hui-231",
+        "deptCode": "HUI",
+        "number": "231",
+        "code": "HUI 231",
+        "title": "HUI 231: Italian Cinema"
+    },
+    {
+        "id": "hur-241",
+        "deptCode": "HUR",
+        "number": "241",
+        "code": "HUR 241",
+        "title": "HUR 241: Russian Cinema"
+    },
+    {
+        "id": "hus-201",
+        "deptCode": "HUS",
+        "number": "201",
+        "code": "HUS 201",
+        "title": "HUS 201: The Hispanic World through Visual Cultures"
+    },
+    {
+        "id": "hus-290",
+        "deptCode": "HUS",
+        "number": "290",
+        "code": "HUS 290",
+        "title": "HUS 290: Latin American Cinema"
+    },
+    {
+        "id": "iae-101",
+        "deptCode": "IAE",
+        "number": "101",
+        "code": "IAE 101",
+        "title": "IAE 101: Digital Intelligence"
+    },
+    {
+        "id": "mus-101",
+        "deptCode": "MUS",
+        "number": "101",
+        "code": "MUS 101",
+        "title": "MUS 101: Introduction to Western Classical Music"
+    },
+    {
+        "id": "mus-103",
+        "deptCode": "MUS",
+        "number": "103",
+        "code": "MUS 103",
+        "title": "MUS 103: Introduction to Music and the Cinema"
+    },
+    {
+        "id": "mus-105",
+        "deptCode": "MUS",
+        "number": "105",
+        "code": "MUS 105",
+        "title": "MUS 105: Music Cultures of the World"
+    },
+    {
+        "id": "mus-109",
+        "deptCode": "MUS",
+        "number": "109",
+        "code": "MUS 109",
+        "title": "MUS 109: Rock, Popular Music, and Society"
+    },
+    {
+        "id": "mus-119",
+        "deptCode": "MUS",
+        "number": "119",
+        "code": "MUS 119",
+        "title": "MUS 119: The Elements of Music"
+    },
+    {
+        "id": "mus-130",
+        "deptCode": "MUS",
+        "number": "130",
+        "code": "MUS 130",
+        "title": "MUS 130: Sound Structures"
+    },
+    {
+        "id": "mus-208",
+        "deptCode": "MUS",
+        "number": "208",
+        "code": "MUS 208",
+        "title": "MUS 208: Introduction to Music Technology"
+    },
+    {
+        "id": "mus-341",
+        "deptCode": "MUS",
+        "number": "341",
+        "code": "MUS 341",
+        "title": "MUS 341: Sound Design"
+    },
+    {
+        "id": "phi-264",
+        "deptCode": "PHI",
+        "number": "264",
+        "code": "PHI 264",
+        "title": "PHI 264: Philosophy and the Arts (III)"
+    },
+    {
+        "id": "spn-420",
+        "deptCode": "SPN",
+        "number": "420",
+        "code": "SPN 420",
+        "title": "SPN 420: Topics in Spanish and Latin American Cinema"
+    },
+    {
+        "id": "thr-100",
+        "deptCode": "THR",
+        "number": "100",
+        "code": "THR 100",
+        "title": "THR 100: Performing and Performance"
+    },
+    {
+        "id": "thr-101",
+        "deptCode": "THR",
+        "number": "101",
+        "code": "THR 101",
+        "title": "THR 101: Introduction to Theatre Arts"
+    },
+    {
+        "id": "thr-103",
+        "deptCode": "THR",
+        "number": "103",
+        "code": "THR 103",
+        "title": "THR 103: Introduction to Theatre Design"
+    },
+    {
+        "id": "thr-105",
+        "deptCode": "THR",
+        "number": "105",
+        "code": "THR 105",
+        "title": "THR 105: Acting I"
+    },
+    {
+        "id": "thr-107",
+        "deptCode": "THR",
+        "number": "107",
+        "code": "THR 107",
+        "title": "THR 107: The Broadway Musical"
+    },
+    {
+        "id": "thr-207",
+        "deptCode": "THR",
+        "number": "207",
+        "code": "THR 207",
+        "title": "THR 207: The Theatre of Baseball"
+    },
+    {
+        "id": "thr-214",
+        "deptCode": "THR",
+        "number": "214",
+        "code": "THR 214",
+        "title": "THR 214: Theatre in New York"
+    },
+    {
+        "id": "thr-216",
+        "deptCode": "THR",
+        "number": "216",
+        "code": "THR 216",
+        "title": "THR 216: Introduction to Visual Interpretation"
+    },
+    {
+        "id": "thr-224",
+        "deptCode": "THR",
+        "number": "224",
+        "code": "THR 224",
+        "title": "THR 224: Experimental Studio"
+    },
+    {
+        "id": "thr-325",
+        "deptCode": "THR",
+        "number": "325",
+        "code": "THR 325",
+        "title": "THR 325: Screenwriting"
+    },
+    {
+        "id": "thr-326",
+        "deptCode": "THR",
+        "number": "326",
+        "code": "THR 326",
+        "title": "THR 326: Playwriting"
+    },
+    {
+        "id": "thr-335",
+        "deptCode": "THR",
+        "number": "335",
+        "code": "THR 335",
+        "title": "THR 335: The Musicals of Stephen Sondheim"
+    }
+]

--- a/src/data/SBCS/GLO.json
+++ b/src/data/SBCS/GLO.json
@@ -1,0 +1,205 @@
+[
+    {
+        "id": "aas-102",
+        "deptCode": "AAS",
+        "number": "102",
+        "code": "AAS 102",
+        "title": "AAS 102: Eastern Religions"
+    },
+    {
+        "id": "aas-201",
+        "deptCode": "AAS",
+        "number": "201",
+        "code": "AAS 201",
+        "title": "AAS 201: Introduction to the Civilization of the Indian Subcontinent"
+    },
+    {
+        "id": "aas-216",
+        "deptCode": "AAS",
+        "number": "216",
+        "code": "AAS 216",
+        "title": "AAS 216: Introduction to Japanese Studies"
+    },
+    {
+        "id": "aas-217",
+        "deptCode": "AAS",
+        "number": "217",
+        "code": "AAS 217",
+        "title": "AAS 217: Introduction to Korean Culture"
+    },
+    {
+        "id": "aas-218",
+        "deptCode": "AAS",
+        "number": "218",
+        "code": "AAS 218",
+        "title": "AAS 218: Ancient, Medieval, & Early Modern South Asia"
+    },
+    {
+        "id": "aas-219",
+        "deptCode": "AAS",
+        "number": "219",
+        "code": "AAS 219",
+        "title": "AAS 219: Japan in the Age of Courtier and Samurai"
+    },
+    {
+        "id": "aas-220",
+        "deptCode": "AAS",
+        "number": "220",
+        "code": "AAS 220",
+        "title": "AAS 220: China: Language and Culture"
+    },
+    {
+        "id": "aas-222",
+        "deptCode": "AAS",
+        "number": "222",
+        "code": "AAS 222",
+        "title": "AAS 222: Indian Cinemas and Cultures"
+    },
+    {
+        "id": "aas-223",
+        "deptCode": "AAS",
+        "number": "223",
+        "code": "AAS 223",
+        "title": "AAS 223: China: Society and Civilization"
+    },
+    {
+        "id": "aas-228",
+        "deptCode": "AAS",
+        "number": "228",
+        "code": "AAS 228",
+        "title": "AAS 228: China: History and Geography"
+    },
+    {
+        "id": "aas-236",
+        "deptCode": "AAS",
+        "number": "236",
+        "code": "AAS 236",
+        "title": "AAS 236: Korean Religions"
+    },
+    {
+        "id": "aas-240",
+        "deptCode": "AAS",
+        "number": "240",
+        "code": "AAS 240",
+        "title": "AAS 240: Confucianism and Daoism"
+    },
+    {
+        "id": "aas-247",
+        "deptCode": "AAS",
+        "number": "247",
+        "code": "AAS 247",
+        "title": "AAS 247: Modern Korea through Visual Culture"
+    },
+    {
+        "id": "aas-256",
+        "deptCode": "AAS",
+        "number": "256",
+        "code": "AAS 256",
+        "title": "AAS 256: Hinduism"
+    },
+    {
+        "id": "aas-260",
+        "deptCode": "AAS",
+        "number": "260",
+        "code": "AAS 260",
+        "title": "AAS 260: Buddhism"
+    },
+    {
+        "id": "aas-280",
+        "deptCode": "AAS",
+        "number": "280",
+        "code": "AAS 280",
+        "title": "AAS 280: Islam"
+    },
+    {
+        "id": "aas-287",
+        "deptCode": "AAS",
+        "number": "287",
+        "code": "AAS 287",
+        "title": "AAS 287: Islam in China"
+    },
+    {
+        "id": "fh-101",
+        "deptCode": "FH",
+        "number": "101",
+        "code": "FH 101",
+        "title": "FH 101: The Wonders of the Black World"
+    },
+    {
+        "id": "afh-205",
+        "deptCode": "AFH",
+        "number": "205",
+        "code": "AFH 205",
+        "title": "AFH 205: Contemporary African Literature"
+    },
+    {
+        "id": "afh-282",
+        "deptCode": "AFH",
+        "number": "282",
+        "code": "AFH 282",
+        "title": "AFH 282: Contemporary Caribbean Women's Literature"
+    },
+    {
+        "id": "afs-223",
+        "deptCode": "AFS",
+        "number": "223",
+        "code": "AFS 223",
+        "title": "AFS 223: Regional History of Africa"
+    },
+    {
+        "id": "amr-101",
+        "deptCode": "AMR",
+        "number": "101",
+        "code": "AMR 101",
+        "title": "AMR 101: Local and Global: National Boundaries and World-Systems"
+    },
+    {
+        "id": "ant-102",
+        "deptCode": "ANT",
+        "number": "102",
+        "code": "ANT 102",
+        "title": "ANT 102: What Makes Us Human?"
+    },
+    {
+        "id": "ant-103",
+        "deptCode": "ANT",
+        "number": "103",
+        "code": "ANT 103",
+        "title": "ANT 103: Archaeology for a Better World"
+    },
+    {
+        "id": "ant-200",
+        "deptCode": "ANT",
+        "number": "200",
+        "code": "ANT 200",
+        "title": "ANT 200: Contemporary and Historical Perspectives on Insular Southeast Asia"
+    },
+    {
+        "id": "arh-201",
+        "deptCode": "ARH",
+        "number": "201",
+        "code": "ARH 201",
+        "title": "ARH 201: Arts of Africa"
+    },
+    {
+        "id": "arh-203",
+        "deptCode": "ARH",
+        "number": "203",
+        "code": "ARH 203",
+        "title": "ARH 203: Arts of Asia"
+    },
+    {
+        "id": "ccs-203",
+        "deptCode": "CCS",
+        "number": "203",
+        "code": "CCS 203",
+        "title": "CCS 203: Cinema History"
+    },
+    {
+        "id": "chi-120",
+        "deptCode": "CHI",
+        "number": "120",
+        "code": "CHI 120",
+        "title": "CHI 120: Elementary Chinese for Heritage Speakers"
+    }
+]

--- a/src/data/SBCS/HUM.json
+++ b/src/data/SBCS/HUM.json
@@ -1,0 +1,93 @@
+[
+    {
+        "id": "aas-102",
+        "deptCode": "AAS",
+        "number": "102",
+        "code": "AAS 102",
+        "title": "AAS 102: Eastern Religions"
+    },
+    {
+        "id": "aas-212",
+        "deptCode": "AAS",
+        "number": "212",
+        "code": "AAS 212",
+        "title": "AAS 212: Asian and Asian American Studies Topics in the Humanities"
+    },
+    {
+        "id": "aas-217",
+        "deptCode": "AAS",
+        "number": "217",
+        "code": "AAS 217",
+        "title": "AAS 217: Introduction to Korean Culture"
+    },
+    {
+        "id": "aas-218",
+        "deptCode": "AAS",
+        "number": "218",
+        "code": "AAS 218",
+        "title": "AAS 218: Ancient, Medieval, & Early Modern South Asia"
+    },
+    {
+        "id": "aas-232",
+        "deptCode": "AAS",
+        "number": "232",
+        "code": "AAS 232",
+        "title": "AAS 232: Introduction to Asian American Fiction and Film"
+    },
+    {
+        "id": "aas-236",
+        "deptCode": "AAS",
+        "number": "236",
+        "code": "AAS 236",
+        "title": "AAS 236: Korean Religions"
+    },
+    {
+        "id": "aas-237",
+        "deptCode": "AAS",
+        "number": "237",
+        "code": "AAS 237",
+        "title": "AAS 237: Introduction to Japanese Literature"
+    },
+    {
+        "id": "aas-240",
+        "deptCode": "AAS",
+        "number": "240",
+        "code": "AAS 240",
+        "title": "AAS 240: Confucianism and Daoism"
+    },
+    {
+        "id": "aas-256",
+        "deptCode": "AAS",
+        "number": "256",
+        "code": "AAS 256",
+        "title": "AAS 256: Hinduism"
+    },
+    {
+        "id": "aas-260",
+        "deptCode": "AAS",
+        "number": "260",
+        "code": "AAS 260",
+        "title": "AAS 260: Buddhism"
+    },
+    {
+        "id": "aas-280",
+        "deptCode": "AAS",
+        "number": "280",
+        "code": "AAS 280",
+        "title": "AAS 280: Islam"
+    },
+    {
+        "id": "aas-287",
+        "deptCode": "AAS",
+        "number": "287",
+        "code": "AAS 287",
+        "title": "AAS 287: Islam in China"
+    },
+    {
+        "id": "afh-205",
+        "deptCode": "AFH",
+        "number": "205",
+        "code": "AFH 205",
+        "title": "AFH 205: Contemporary African Literature"
+    }
+]

--- a/src/data/SBCS/LANG.json
+++ b/src/data/SBCS/LANG.json
@@ -1,0 +1,100 @@
+[
+    {
+        "id": "chi-111",
+        "deptCode": "CHI",
+        "number": "111",
+        "code": "CHI 111",
+        "title": "CHI 111: Elementary Chinese I"
+    },
+    {
+        "id": "chi-112",
+        "deptCode": "CHI",
+        "number": "112",
+        "code": "CHI 112",
+        "title": "CHI 112: Elementary Chinese II"
+    },
+    {
+        "id": "spn-111",
+        "deptCode": "SPN",
+        "number": "111",
+        "code": "SPN 111",
+        "title": "SPN 111: Elementary Spanish I"
+    },
+    {
+        "id": "spn-112",
+        "deptCode": "SPN",
+        "number": "112",
+        "code": "SPN 112",
+        "title": "SPN 112: Elementary Spanish II"
+    },
+    {
+        "id": "kor-111",
+        "deptCode": "KOR",
+        "number": "111",
+        "code": "KOR 111",
+        "title": "KOR 111: Elementary Korean I"
+    },
+    {
+        "id": "kor-112",
+        "deptCode": "KOR",
+        "number": "112",
+        "code": "KOR 112",
+        "title": "KOR 112: Elementary Korean II"
+    },
+    {
+        "id": "frn-111",
+        "deptCode": "FRN",
+        "number": "111",
+        "code": "FRN 111",
+        "title": "FRN 111: Elementary French I"
+    },
+    {
+        "id": "frn-112",
+        "deptCode": "FRN",
+        "number": "112",
+        "code": "FRN 112",
+        "title": "FRN 112: Elementary French II"
+    },
+    {
+        "id": "ger-111",
+        "deptCode": "GER",
+        "number": "111",
+        "code": "GER 111",
+        "title": "GER 111: Elementary German I"
+    },
+    {
+        "id": "ger-112",
+        "deptCode": "GER",
+        "number": "112",
+        "code": "GER 112",
+        "title": "GER 112: Elementary German II"
+    },
+    {
+        "id": "ita-111",
+        "deptCode": "ITA",
+        "number": "111",
+        "code": "ITA 111",
+        "title": "ITA 111: Elementary Italian I"
+    },
+    {
+        "id": "ita-112",
+        "deptCode": "ITA",
+        "number": "112",
+        "code": "ITA 112",
+        "title": "ITA 112: Elementary Italian II"
+    },
+    {
+        "id": "jpn-111",
+        "deptCode": "JPN",
+        "number": "111",
+        "code": "JPN 111",
+        "title": "JPN 111: Elementary Japanese I"
+    },
+    {
+        "id": "jpn-112",
+        "deptCode": "JPN",
+        "number": "112",
+        "code": "JPN 112",
+        "title": "JPN 112: Elementary Japanese II"
+    }
+]

--- a/src/data/SBCS/QPS.json
+++ b/src/data/SBCS/QPS.json
@@ -1,0 +1,72 @@
+[
+    {
+        "id": "ams-102",
+        "deptCode": "AMS",
+        "number": "102",
+        "code": "AMS 102",
+        "title": "AMS 102: Elements of Statistics"
+    },
+    {
+        "id": "ams-110",
+        "deptCode": "AMS",
+        "number": "110",
+        "code": "AMS 110",
+        "title": "AMS 110: Probability and Statistics in the Life Sciences"
+    },
+    {
+        "id": "ams-151",
+        "deptCode": "AMS",
+        "number": "151",
+        "code": "AMS 151",
+        "title": "AMS 151: Applied Calculus I"
+    },
+    {
+        "id": "ams-161",
+        "deptCode": "AMS",
+        "number": "161",
+        "code": "AMS 161",
+        "title": "AMS 161: Applied Calculus II"
+    },
+    {
+        "id": "mat-123",
+        "deptCode": "MAT",
+        "number": "123",
+        "code": "MAT 123",
+        "title": "MAT 123: Precalculus Mathematics"
+    },
+    {
+        "id": "mat-125",
+        "deptCode": "MAT",
+        "number": "125",
+        "code": "MAT 125",
+        "title": "MAT 125: Calculus A"
+    },
+    {
+        "id": "mat-126",
+        "deptCode": "MAT",
+        "number": "126",
+        "code": "MAT 126",
+        "title": "MAT 126: Calculus B"
+    },
+    {
+        "id": "mat-130",
+        "deptCode": "MAT",
+        "number": "130",
+        "code": "MAT 130",
+        "title": "MAT 130: Calculus with Applications"
+    },
+    {
+        "id": "mat-131",
+        "deptCode": "MAT",
+        "number": "131",
+        "code": "MAT 131",
+        "title": "MAT 131: Calculus I"
+    },
+    {
+        "id": "mat-132",
+        "deptCode": "MAT",
+        "number": "132",
+        "code": "MAT 132",
+        "title": "MAT 132: Calculus II"
+    }
+]

--- a/src/data/SBCS/SBS.json
+++ b/src/data/SBCS/SBS.json
@@ -1,0 +1,51 @@
+[
+    {
+        "id": "eco-108",
+        "deptCode": "ECO",
+        "number": "108",
+        "code": "ECO 108",
+        "title": "ECO 108: Introduction to Economics"
+    },
+    {
+        "id": "his-103",
+        "deptCode": "HIS",
+        "number": "103",
+        "code": "HIS 103",
+        "title": "HIS 103: American History to 1877"
+    },
+    {
+        "id": "his-104",
+        "deptCode": "HIS",
+        "number": "104",
+        "code": "HIS 104",
+        "title": "HIS 104: United States Since 1877"
+    },
+    {
+        "id": "pol-101",
+        "deptCode": "POL",
+        "number": "101",
+        "code": "POL 101",
+        "title": "POL 101: World Politics"
+    },
+    {
+        "id": "pol-102",
+        "deptCode": "POL",
+        "number": "102",
+        "code": "POL 102",
+        "title": "POL 102: Introduction to American Government"
+    },
+    {
+        "id": "psy-103",
+        "deptCode": "PSY",
+        "number": "103",
+        "code": "PSY 103",
+        "title": "PSY 103: Introduction to Psychology"
+    },
+    {
+        "id": "soc-247",
+        "deptCode": "SOC",
+        "number": "247",
+        "code": "SOC/WST 247",
+        "title": "SOC 247 / WST 247: Sociology of Gender"
+    }
+]

--- a/src/data/SBCS/SNW.json
+++ b/src/data/SBCS/SNW.json
@@ -1,0 +1,51 @@
+[
+    {
+        "id": "bio-103",
+        "deptCode": "BIO",
+        "number": "103",
+        "code": "BIO 103",
+        "title": "BIO 103: Introduction to Biotechnology"
+    },
+    {
+        "id": "bio-113",
+        "deptCode": "BIO",
+        "number": "113",
+        "code": "BIO 113",
+        "title": "BIO 113: General Ecology"
+    },
+    {
+        "id": "bio-114",
+        "deptCode": "BIO",
+        "number": "114",
+        "code": "BIO 114",
+        "title": "BIO 114: Dinosaur Paleontology"
+    },
+    {
+        "id": "bio-201",
+        "deptCode": "BIO",
+        "number": "201",
+        "code": "BIO 201",
+        "title": "BIO 201: Fundamentals of Biology: Organisms to Ecosystems"
+    },
+    {
+        "id": "che-115",
+        "deptCode": "CHE",
+        "number": "115",
+        "code": "CHE 115",
+        "title": "CHE 115: Chemistry, Life, and Environment"
+    },
+    {
+        "id": "che-129",
+        "deptCode": "CHE",
+        "number": "129",
+        "code": "CHE 129",
+        "title": "CHE 129: General Chemistry I"
+    },
+    {
+        "id": "che-132",
+        "deptCode": "CHE",
+        "number": "132",
+        "code": "CHE 132",
+        "title": "CHE 132: General Chemistry II"
+    }
+]

--- a/src/data/SBCS/TECH.json
+++ b/src/data/SBCS/TECH.json
@@ -1,0 +1,93 @@
+[
+    {
+        "id": "est-100",
+        "deptCode": "EST",
+        "number": "100",
+        "code": "EST 100",
+        "title": "EST 100: Designing, Producing & Presenting Multimedia Projects"
+    },
+    {
+        "id": "est-105",
+        "deptCode": "EST",
+        "number": "105",
+        "code": "EST 105",
+        "title": "EST 105: The Digital Generation: Leveraging Technology to Build 21st Century Skills"
+    },
+    {
+        "id": "est-202",
+        "deptCode": "EST",
+        "number": "202",
+        "code": "EST 202",
+        "title": "EST 202: Introduction to Science, Technology, and Society Studies"
+    },
+    {
+        "id": "cse-101",
+        "deptCode": "CSE",
+        "number": "101",
+        "code": "CSE 101",
+        "title": "CSE 101: Introduction to Computing"
+    },
+    {
+        "id": "cse-114",
+        "deptCode": "CSE",
+        "number": "114",
+        "code": "CSE 114",
+        "title": "CSE 114: Introduction to Object-Oriented Programming"
+    },
+    {
+        "id": "est-205",
+        "deptCode": "EST",
+        "number": "205",
+        "code": "EST 205",
+        "title": "EST 205: Introduction to Technological Design: Innovation and Design Thinking"
+    },
+    {
+        "id": "est-207",
+        "deptCode": "EST",
+        "number": "207",
+        "code": "EST 207",
+        "title": "EST 207: Technology in Culture and Society"
+    },
+    {
+        "id": "est-221",
+        "deptCode": "EST",
+        "number": "221",
+        "code": "EST 221",
+        "title": "EST 221: Introduction to Digital Media"
+    },
+    {
+        "id": "est-240",
+        "deptCode": "EST",
+        "number": "240",
+        "code": "EST 240",
+        "title": "EST 240: Digital Tools and Creative Practices"
+    },
+    {
+        "id": "est-280",
+        "deptCode": "EST",
+        "number": "280",
+        "code": "EST 280",
+        "title": "EST 280: Technology and the Environment"
+    },
+    {
+        "id": "est-291",
+        "deptCode": "EST",
+        "number": "291",
+        "code": "EST 291",
+        "title": "EST 291: Emerging Technologies and Society"
+    },
+    {
+        "id": "est-310",
+        "deptCode": "EST",
+        "number": "310",
+        "code": "EST 310",
+        "title": "EST 310: Advanced Topics in Technology Studies"
+    },
+    {
+        "id": "ise-305",
+        "deptCode": "ISE",
+        "number": "305",
+        "code": "ISE 305",
+        "title": "ISE 305: Information Systems and Technology"
+    }
+]

--- a/src/data/SBCS/USA.json
+++ b/src/data/SBCS/USA.json
@@ -1,0 +1,79 @@
+[
+    {
+        "id": "his-215",
+        "deptCode": "HIS",
+        "number": "215",
+        "code": "HIS 215",
+        "title": "HIS 215: Long Island History"
+    },
+    {
+        "id": "his-261",
+        "deptCode": "HIS",
+        "number": "261",
+        "code": "HIS 261",
+        "title": "HIS 261: Change and Reform in the United States, 1877-1919"
+    },
+    {
+        "id": "his-262",
+        "deptCode": "HIS",
+        "number": "262",
+        "code": "HIS 262",
+        "title": "HIS 262: American Colonial Society"
+    },
+    {
+        "id": "his-263",
+        "deptCode": "HIS",
+        "number": "263",
+        "code": "HIS 263",
+        "title": "HIS 263: Age of the American Revolution"
+    },
+    {
+        "id": "his-264",
+        "deptCode": "HIS",
+        "number": "264",
+        "code": "HIS 264",
+        "title": "HIS 264: The Early Republic"
+    },
+    {
+        "id": "his-265",
+        "deptCode": "HIS",
+        "number": "265",
+        "code": "HIS 265",
+        "title": "HIS 265: Civil War and Reconstruction"
+    },
+    {
+        "id": "his-266",
+        "deptCode": "HIS",
+        "number": "266",
+        "code": "HIS 266",
+        "title": "HIS 266: History of the United States West"
+    },
+    {
+        "id": "his-273",
+        "deptCode": "HIS",
+        "number": "273",
+        "code": "HIS 273",
+        "title": "HIS 273: U.S. History, 1900-1945"
+    },
+    {
+        "id": "his-277",
+        "deptCode": "HIS",
+        "number": "277",
+        "code": "HIS 277",
+        "title": "HIS 277: The Modern Color Line"
+    },
+    {
+        "id": "pol-102",
+        "deptCode": "POL",
+        "number": "102",
+        "code": "POL 102",
+        "title": "POL 102: Introduction to American Government"
+    },
+    {
+        "id": "com-208",
+        "deptCode": "COM",
+        "number": "208",
+        "code": "COM 208",
+        "title": "COM 208: History of Mass Communication"
+    }
+]

--- a/src/data/SBCS/WRT.json
+++ b/src/data/SBCS/WRT.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "wrt-102",
+    "deptCode": "WRT",
+    "number": "102",
+    "code": "WRT 102",
+    "title": "WRT 102: College Writing"
+  },
+  {
+    "id": "wrt-105",
+    "deptCode": "WRT",
+    "number": "105",
+    "code": "WRT 105",
+    "title": "WRT 105: Writing About Literature"
+  },
+  {
+    "id": "wrt-110",
+    "deptCode": "WRT",
+    "number": "110",
+    "code": "WRT 110",
+    "title": "WRT 110: Writing About Film and Media"
+  },
+  {
+    "id": "wrt-201",
+    "deptCode": "WRT",
+    "number": "201",
+    "code": "WRT 201",
+    "title": "WRT 201: Writing About Society"
+  },
+  {
+    "id": "wrt-202",
+    "deptCode": "WRT",
+    "number": "202",
+    "code": "WRT 202",
+    "title": "WRT 202: Writing About Science and Technology"
+  },
+  {
+    "id": "wrt-203",
+    "deptCode": "WRT",
+    "number": "203",
+    "code": "WRT 203",
+    "title": "WRT 203: Writing About the Arts"
+  },
+  {
+    "id": "wrt-205",
+    "deptCode": "WRT",
+    "number": "205",
+    "code": "WRT 205",
+    "title": "WRT 205: Writing About Culture and Media"
+  }
+]

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -17,31 +17,73 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../supabaseClient';
 
+const AUTH_INIT_TIMEOUT_MS = 7000;
+
 export function useAuth() {
   const [user, setUser] = useState(null);
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
   const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    // Get initial session on mount
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-      setUser(session?.user ?? null);
+    let isMounted = true;
+
+    const timeoutId = window.setTimeout(() => {
+      if (!isMounted) return;
+      console.warn('Supabase auth initialization timed out. Continuing without a session.');
       setLoading(false);
-    });
+    }, AUTH_INIT_TIMEOUT_MS);
+
+    async function initializeSession() {
+      try {
+        const {
+          data: { session },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError) {
+          throw sessionError;
+        }
+
+        if (!isMounted) return;
+        setSession(session);
+        setUser(session?.user ?? null);
+        setError(null);
+      } catch (authError) {
+        if (!isMounted) return;
+        console.error('Failed to initialize auth session:', authError);
+        setSession(null);
+        setUser(null);
+        setError(authError);
+      } finally {
+        window.clearTimeout(timeoutId);
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    initializeSession();
 
     // Listen for auth state changes (login, logout, token refresh)
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) return;
+      window.clearTimeout(timeoutId);
       setSession(session);
       setUser(session?.user ?? null);
+      setError(null);
       setLoading(false);
     });
 
     // Cleanup subscription on unmount
-    return () => subscription.unsubscribe();
+    return () => {
+      isMounted = false;
+      window.clearTimeout(timeoutId);
+      subscription.unsubscribe();
+    };
   }, []);
 
   // Sign out helper
@@ -75,6 +117,7 @@ export function useAuth() {
     user,
     session,
     loading,
+    error,
     signOut,
     signingOut,
   };

--- a/src/pages/DegreeProgressPage.js
+++ b/src/pages/DegreeProgressPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import DegreeProgress from '../components/DegreeProgress';
+
+export default function DegreeProgressPage() {
+  return (
+    <div className="min-h-screen bg-[#F9FAFB] text-gray-900 pb-10">
+      <DegreeProgress />
+    </div>
+  );
+}

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -3,6 +3,7 @@ import NodeInfo from '../components/NodeInfo'; // previously ProfessorInfo
 import CourseGraph from '../components/GraphComponent';
 import Legend from '../components/Legend';
 import RadialGraphComponent from '../components/RadialGraphComponent';
+import SpecializationDetailsPanel from '../components/SpecializationDetailsPanel';
 import courses from '../data/sbu_cse_courses_new_schema.json';
 
 function Home() {
@@ -52,8 +53,9 @@ function Home() {
         </div>
 
         <div className="col-span-1 bg-white rounded-lg p-3">
-          <NodeInfo course={selectedCourse} />
           <Legend />
+          <SpecializationDetailsPanel />
+          <NodeInfo course={selectedCourse} />
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- New **/degree-progress** route — read-only GE category tracker (ARTS/GLO/HUM/LANG/QPS/SBS/SNW/TECH/USA/WRT) sourced from SBCS_UI branch (albert), refactored to share state with the graph via \`user_progress.external_courses\`.
- Merged \`feature/taken-courses-tracker\` (josh): new \`SpecializationSelector\` design, \`SpecializationDetailsPanel\`, \`CompletedCoursesPanel\`, Legend ring entry, \`useAuth\` loading hardening, Home sidebar reorg.
- Patched \`completedCourseCodes\` memo so SBCS GE entries flow into specialization progress.

## Conflict resolutions taken in the merge
- \`SpecializationSelector.js\`: took josh's full rewrite. The earlier polish commit \`0b3fe11\` is superseded.
- \`GraphComponent.js\`: took josh's combined \`completedCourseCodes\` prop shape, then unioned in \`externalCourses\` so SBCS course entries count.

## Skipped from SBCS_UI
- App.js auth-guard removal (regression).
- Home.js multi-major code (superseded by #48).
- DegreeProgress2/3/Panel (unwired UI variants).

## Test plan
- [ ] \`/degree-progress\` renders; sign in and type a GE course (e.g. \`AAS 102\` for HUM) — category auto-ticks.
- [ ] Reload — typed code persists.
- [ ] Same code appears in graph's external-courses pill list.
- [ ] Specialization progress reflects courses added on either surface.
- [ ] LANG flips to "Exempt" when major dropdown is one of: CEAS / Athletic Training / Respiratory Care / Clinical Laboratory Sciences / Social Work.
- [ ] Josh's Taken Courses panel + Specialization Details panel render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)