### PR TITLE
Chatbot navbar + specialization descriptions and rules

### DIFF
--- a/src/components/SpecializationDetailsPanel.js
+++ b/src/components/SpecializationDetailsPanel.js
@@ -23,6 +23,61 @@ export default function SpecializationDetailsPanel() {
         </p>
       </div>
 
+      {specialization.description && (
+        <div className="mb-3 rounded-lg border border-emerald-100 bg-emerald-50/60 p-2.5">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-emerald-700 mb-1">
+            About
+          </div>
+          <p className="text-xs leading-relaxed text-slate-700">
+            {specialization.description}
+          </p>
+        </div>
+      )}
+
+      {specialization.rules && (
+        <div className="mb-3 rounded-lg border border-slate-200 bg-white p-2.5">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 mb-2">
+            Requirements
+          </div>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {specialization.rules.totalCourses != null && (
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                {specialization.rules.totalCourses} courses total
+              </span>
+            )}
+            {specialization.rules.coreMin != null && (
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                ≥ {specialization.rules.coreMin} core
+              </span>
+            )}
+            {specialization.rules.declarationCoreMin != null && (
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-700">
+                Declare after {specialization.rules.declarationCoreMin} core
+              </span>
+            )}
+          </div>
+
+          {specialization.rules.declarationCoreMin != null && (() => {
+            const need = specialization.rules.declarationCoreMin;
+            const have = specialization.coreCompleted || 0;
+            const eligible = have >= need;
+            return (
+              <div
+                className={`rounded-md px-2.5 py-1.5 text-[11px] font-medium ${
+                  eligible
+                    ? 'bg-green-100 text-green-900 border border-green-300'
+                    : 'bg-amber-50 text-amber-900 border border-amber-200'
+                }`}
+              >
+                {eligible
+                  ? `Eligible to declare — ${have}/${need} core courses tracked.`
+                  : `${have}/${need} core courses tracked — ${need - have} more to declare.`}
+              </div>
+            );
+          })()}
+        </div>
+      )}
+
       <div className="grid gap-2 mb-3">
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-2.5">
           <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Overview</div>

--- a/src/components/SpecializationSelector.js
+++ b/src/components/SpecializationSelector.js
@@ -121,6 +121,12 @@ export default function SpecializationSelector({
 
     const completedCount = (detailSpec.courses || []).filter((code) => completedCourseCodes.has(code)).length;
 
+    const coreSection = detailSections.find((s) =>
+      (s.label || '').toLowerCase().includes('core')
+    );
+    const coreCompleted = coreSection ? coreSection.completedCount : 0;
+    const coreTotal = coreSection ? (coreSection.courses?.length || 0) : 0;
+
     window.dispatchEvent(
       new CustomEvent('specialization:selected', {
         detail: {
@@ -129,9 +135,13 @@ export default function SpecializationSelector({
             majorUrl: major.url,
             name: detailSpec.name,
             slug: detailSpec.slug,
+            description: detailSpec.description || null,
+            rules: detailSpec.rules || null,
             totalCount: detailSpec.courses?.length || 0,
             completedCount,
             remainingCount: Math.max((detailSpec.courses?.length || 0) - completedCount, 0),
+            coreCompleted,
+            coreTotal,
             sections: detailSections,
           },
         },

--- a/src/data/courses/specializations.json
+++ b/src/data/courses/specializations.json
@@ -162,6 +162,12 @@
       {
         "name": "Artificial Intelligence and Data Science",
         "slug": "artificial-intelligence-and-data-science",
+        "description": "The specialization in artificial intelligence and data science emphasizes modern approaches for building intelligent systems using machine learning. It requires four courses selected from the list below. The four courses must include at least two core courses. Students may declare their participation in the specialization after completing two core courses.",
+        "rules": {
+          "totalCourses": 4,
+          "coreMin": 2,
+          "declarationCoreMin": 2
+        },
         "sections": [
           {
             "label": "Core Courses",
@@ -210,6 +216,8 @@
       {
         "name": "Human-Computer Interaction",
         "slug": "human-computer-interaction",
+        "description": "The specialization in human-computer interaction focuses on designing, building, and evaluating systems that people use directly. The track combines a set of HCI core courses with electives across CSE and Psychology and culminates in a project course.",
+        "rules": null,
         "sections": [
           {
             "label": "Core Courses",
@@ -273,6 +281,8 @@
       {
         "name": "Game Programming",
         "slug": "game-programming",
+        "description": "The specialization in game programming covers graphics, real-time systems, game engines, and the project work needed to ship interactive entertainment software. The track combines core courses with electives and a final project course.",
+        "rules": null,
         "sections": [
           {
             "label": "Core Courses",
@@ -334,6 +344,8 @@
       {
         "name": "Security and Privacy",
         "slug": "security-and-privacy",
+        "description": "The specialization in security and privacy covers the foundations and practice of building systems that resist attack and protect user data. The track combines required core courses in security with electives across systems, networking, and applied cryptography.",
+        "rules": null,
         "sections": [
           {
             "label": "Core Courses",
@@ -384,6 +396,8 @@
       {
         "name": "Systems Software Development",
         "slug": "systems-software-development",
+        "description": "The specialization in systems software development covers the engineering of operating systems, compilers, networks, and other infrastructure software. Students choose from a list of advanced systems-oriented CSE courses.",
+        "rules": null,
         "sections": [
           {
             "label": null,
@@ -1126,7 +1140,7 @@
   },
   {
     "majorId": "women-s-and-gender-studies-ba",
-    "majorName": "Women’s and Gender Studies, BA",
+    "majorName": "Women\u2019s and Gender Studies, BA",
     "poid": 409,
     "url": "https://catalog.stonybrook.edu/preview_program.php?catoid=7&poid=409&returnto=224",
     "specializations": [

--- a/src/pages/ChatBotPage.js
+++ b/src/pages/ChatBotPage.js
@@ -1,6 +1,12 @@
 import React from 'react';
+import Navbar from '../components/navbar';
 import ChatBot from '../components/ChatBot';
 
 export default function ChatBotPage() {
-  return <ChatBot />;
+  return (
+    <div className="App">
+      <Navbar />
+      <ChatBot />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- **Navbar on /chatbot**: \`ChatBotPage\` now wraps \`<ChatBot />\` with \`<Navbar />\` so the no-auth chatbot route has navigation back to the rest of the app.
- **Specialization metadata**: extended \`specializations.json\` with optional \`description\` and \`rules\` ({\`totalCourses\`, \`coreMin\`, \`declarationCoreMin\`}) per spec.
- **AI and Data Science** populated with the catalog text and full rules (4 courses, ≥2 core, declare after 2 core).
- The other four CSE specs got summary descriptions; their \`rules\` are left \`null\` because the SBU catalog specifics differ per track and I don't want to fabricate them — they can be filled in later.
- **SpecializationSelector** emits \`description\`, \`rules\`, and core-section progress in its event payload.
- **SpecializationDetailsPanel** renders three new blocks: an About blurb, a Requirements row of pills (\"4 courses total\" / \"≥ 2 core\" / \"Declare after 2 core\"), and a declaration-eligibility banner that flips green when the tracked core count meets the threshold.

## Test plan
- [ ] Visit /chatbot — navbar is visible and links navigate correctly.
- [ ] On Home, select CSE major, click "Artificial Intelligence and Data Science" — sidebar shows description, three rule pills, and an amber "0/2 core courses tracked — 2 more to declare" banner.
- [ ] Mark one core course (e.g. CSE 351) completed — banner updates to "1/2 core courses tracked".
- [ ] Mark two core courses — banner flips green: "Eligible to declare".
- [ ] Other CSE specs (HCI, Game, Security, Systems Software) show description but no rules block (rules are null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)